### PR TITLE
Update 2FA section

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ A curated list of awesome open source Android applications, tutorials and resour
 ### 2FA and TOTP
 
 - [Aegis](https://github.com/beemdevelopment/Aegis) - Free, secure and open source 2FA app for Android.
+- [andOTP](https://github.com/andOTP/andOTP) - Open source two-factor authentication for Android.
 - [AuthenticatorPro](https://github.com/jamie-mh/AuthenticatorPro) - Free and open source 2FA app with support for Wear OS.
 
 ## Personalisation

--- a/README.md
+++ b/README.md
@@ -174,8 +174,8 @@ A curated list of awesome open source Android applications, tutorials and resour
 
 ### 2FA and TOTP
 
-- [andOTP](https://github.com/andOTP/andOTP) - Open source two-factor authentication for Android.
 - [Aegis](https://github.com/beemdevelopment/Aegis) - Free, secure and open source 2FA app for Android.
+- [AuthenticatorPro](https://github.com/jamie-mh/AuthenticatorPro) - Free and open source 2FA app with support for Wear OS.
 
 ## Personalisation
 


### PR DESCRIPTION
I removed andOTP, because I don't think it's worth trusting the security considering this: https://github.com/andOTP/andOTP#help-wanted

I added Authenticator pro, it's very actively deleped and also has suport for Wear OS, which is rare, Wear OS has problem with app availability in some categories, so folk might find this useful.